### PR TITLE
Fix typo in FilterCriteria enum

### DIFF
--- a/src/tools/filter.test.ts
+++ b/src/tools/filter.test.ts
@@ -13,7 +13,7 @@ describe("Filter", () => {
   test.each`
     criteria                               | negate   | expected
     ${FilterCriteria.PotentiallyHabitable} | ${false} | ${[proximaCenB]}
-    ${FilterCriteria.OnlyNonContoversial}  | ${true}  | ${[proximaCenB, gj411b, tauCetg]}
+    ${FilterCriteria.OnlyNonControversial} | ${true}  | ${[proximaCenB, gj411b, tauCetg]}
   `("evaluate", ({ criteria, negate, expected }) => {
     let actual: Planet[] = [];
     if (negate) {

--- a/src/tools/filter.ts
+++ b/src/tools/filter.ts
@@ -1,7 +1,7 @@
 import { Planet } from "../types";
 
 export enum FilterCriteria {
-  OnlyNonContoversial = "ONLY_NON_CONTROVERSIAL",
+  OnlyNonControversial = "ONLY_NON_CONTROVERSIAL",
   PotentiallyHabitable = "POTENTIALLY_HABITABLE",
 }
 
@@ -27,7 +27,7 @@ export const createFilter = (criteria?: FilterCriteria): Filter => {
         case FilterCriteria.PotentiallyHabitable:
           key = "potentiallyHabitable";
           break;
-        case FilterCriteria.OnlyNonContoversial:
+        case FilterCriteria.OnlyNonControversial:
           key = "controversial";
           break;
       }


### PR DESCRIPTION
OnlyNonContoversial was renamed to OnlyNonCont**r**oversial. Tests are still green after this change.